### PR TITLE
Broadcasting action to all frames

### DIFF
--- a/src/main/java/org/inventivetalent/animatedframes/Commands.java
+++ b/src/main/java/org/inventivetalent/animatedframes/Commands.java
@@ -342,6 +342,33 @@ public class Commands {
 		plugin.frameManager.startFrame(frame);
 	}
 
+	@Command(name = "framestart-all",
+			aliases = {
+			"afstart-all",
+			"startframe-all",
+			"frameresume-all",
+			"afresume-all",
+			"resumeframe-all"
+			},
+			description = "Start all stopped/paused frames",
+			fallbackPrefix = "animatedframes")
+	@Permission("animatedframes.start.all")
+	public void frameStartAll(final CommandSender sender) {
+		if (plugin.frameManager.getFrames().size() == 0) {
+			sender.sendMessage(MESSAGE_LOADER.getMessage("start.all.error.empty", "start.all.error.empty"));
+			return;
+		}
+		for (final AnimatedFrame frame : plugin.frameManager.getFrames()) {
+			if (frame.isPlaying()) {
+				sender.sendMessage(MESSAGE_LOADER.getMessage("start.all.error.playing", "start.all.error.playing").replaceAll("%name%", frame.getName()));
+				continue;
+			}
+			sender.sendMessage(MESSAGE_LOADER.getMessage("start.all.starting", "start.all.starting").replaceAll("%name%", frame.getName()));
+			frame.setPlaying(true);
+			plugin.frameManager.startFrame(frame);
+		}
+	}
+
 	@Command(name = "framepause",
 			 aliases = {
 					 "afpause",
@@ -366,6 +393,29 @@ public class Commands {
 
 		sender.sendMessage(MESSAGE_LOADER.getMessage("pause.pausing", "pause.pausing"));
 		plugin.frameManager.stopFrame(frame);
+	}
+
+	@Command(name = "framepause-all",
+			aliases = {
+					"afpause-all",
+					"pauseframe-all"
+			},
+			description = "Pauses all started frames",
+			fallbackPrefix = "animatedframes")
+	@Permission("animatedframes.pause.all")
+	public void framePauseAll(final CommandSender sender) {
+		if (plugin.frameManager.getFrames().size() == 0) {
+			sender.sendMessage(MESSAGE_LOADER.getMessage("pause.all.error.empty", "pause.all.error.empty"));
+			return;
+		}
+		for (final AnimatedFrame frame : plugin.frameManager.getFrames()) {
+			if (!frame.isPlaying()) {
+				sender.sendMessage(MESSAGE_LOADER.getMessage("pause.all.error.notPlaying", "pause.all.error.notPlaying").replaceAll("%name%", frame.getName()));
+				continue;
+			}
+			sender.sendMessage(MESSAGE_LOADER.getMessage("pause.all.pausing", "pause.all.pausing").replaceAll("%name%", frame.getName()));
+			plugin.frameManager.stopFrame(frame);
+		}
 	}
 
 	@Command(name = "framestop",
@@ -393,6 +443,30 @@ public class Commands {
 		sender.sendMessage(MESSAGE_LOADER.getMessage("stop.stopping", "stop.stopping"));
 		plugin.frameManager.stopFrame(frame);
 		frame.setCurrentFrame(0);
+	}
+
+	@Command(name = "framestop-all",
+			aliases = {
+					"afstop-all",
+					"stopframe-all"
+			},
+			description = "Stop all started frames",
+			fallbackPrefix = "animatedframes")
+	@Permission("animatedframes.stop.all")
+	public void frameStopAll(final CommandSender sender) {
+		if (plugin.frameManager.getFrames().size() == 0) {
+			sender.sendMessage(MESSAGE_LOADER.getMessage("stop.all.error.empty", "stop.all.error.empty"));
+			return;
+		}
+		for (final AnimatedFrame frame : plugin.frameManager.getFrames()) {
+			if (!frame.isPlaying()) {
+				sender.sendMessage(MESSAGE_LOADER.getMessage("stop.all.error.notPlaying", "stop.all.error.notPlaying").replaceAll("%name%", frame.getName()));
+				continue;
+			}
+			sender.sendMessage(MESSAGE_LOADER.getMessage("stop.all.stopping", "stop.all.stopping").replaceAll("%name%", frame.getName()));
+			plugin.frameManager.stopFrame(frame);
+			frame.setCurrentFrame(0);
+		}
 	}
 
 	@Command(name = "framenext",

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -43,16 +43,31 @@ message:
       error:
         notFound: "&cFrame not found"
         playing: "&cFrame is already playing"
+      all:
+        starting: "&eStarting animation of &f%name%&e..."
+        error:
+          empty: "&cNo frames found to start!"
+          playing: "&cFrame &f%name% &cis already playing"
     stop:
-      stopping: "&Stopping animation..."
+      stopping: "&eStopping animation..."
       error:
         notFound: "&cFrame not found"
         notPlaying: "&cFrame is not playing"
+      all:
+        stopping: "&eStopping animation of &f%name%&e..."
+        error:
+          empty: "&cNo frames found to stop!"
+          notPlaying: "&cFrame &f%name% &cis not playing"
     pause:
       pausing: "&ePausing animation..."
       error:
         notFound: "&cFrame not found"
         notPlaying: "&cFrame is not playing"
+      all:
+        pausing: "&ePausing animation of &f%name%&e..."
+        error:
+          empty: "&cNo frames found to pause!"
+          notPlaying: "&cFrame &f%name% &cis not playing"
     next:
       success: "&eSkipped to next frame"
       error:


### PR DESCRIPTION
Hello @InventivetalentDev o/

Since there's an option to turn off starting frames on server startup. This PR provides the player the ability to broadcast actions to all frames (e.g. `start`, `pause` and `stop`) to help servers with many frames. 😄 

# Fixes
- Default frame stop message has no color