### PR TITLE
Sort frames alphabetically for /aflist

### DIFF
--- a/src/main/java/org/inventivetalent/animatedframes/Commands.java
+++ b/src/main/java/org/inventivetalent/animatedframes/Commands.java
@@ -58,10 +58,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 
 public class Commands {
 
@@ -286,7 +283,7 @@ public class Commands {
 	public void frameList(final Player sender) {
 		sender.sendMessage("  ");
 
-		Set<AnimatedFrame> frames = plugin.frameManager.getFrames();
+		Collection<AnimatedFrame> frames = plugin.frameManager.getFrames();
 		sender.sendMessage("§eFrames (" + frames.size() + "): ");
 		for (AnimatedFrame frame : frames) {
 			TextComponent component = new TextComponent(frame.getName());

--- a/src/main/java/org/inventivetalent/animatedframes/Commands.java
+++ b/src/main/java/org/inventivetalent/animatedframes/Commands.java
@@ -283,7 +283,7 @@ public class Commands {
 	public void frameList(final Player sender) {
 		sender.sendMessage("  ");
 
-		Collection<AnimatedFrame> frames = plugin.frameManager.getFrames();
+		List<AnimatedFrame> frames = plugin.frameManager.getSortedFrames();
 		sender.sendMessage("§eFrames (" + frames.size() + "): ");
 		for (AnimatedFrame frame : frames) {
 			TextComponent component = new TextComponent(frame.getName());

--- a/src/main/java/org/inventivetalent/animatedframes/FrameManager.java
+++ b/src/main/java/org/inventivetalent/animatedframes/FrameManager.java
@@ -222,8 +222,13 @@ public class FrameManager {
 	}
 
 	@Synchronized
-	public Collection<AnimatedFrame> getFrames() {
-		return frameMap.values();
+	public Set<AnimatedFrame> getFrames() {
+		return new HashSet<>(frameMap.values());
+	}
+
+	@Synchronized
+	public List<AnimatedFrame> getSortedFrames() {
+		return new ArrayList<>(frameMap.values());
 	}
 
 	@Synchronized

--- a/src/main/java/org/inventivetalent/animatedframes/FrameManager.java
+++ b/src/main/java/org/inventivetalent/animatedframes/FrameManager.java
@@ -49,10 +49,7 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLEncoder;
 import java.nio.file.Files;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeMap;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 
@@ -225,8 +222,8 @@ public class FrameManager {
 	}
 
 	@Synchronized
-	public Set<AnimatedFrame> getFrames() {
-		return new HashSet<>(frameMap.values());
+	public Collection<AnimatedFrame> getFrames() {
+		return frameMap.values();
 	}
 
 	@Synchronized


### PR DESCRIPTION
## Why 

It would be nice to have the `/aflist` output sorted alphabetically.

## How 

In FrameManager, the AnimatedFrames in `frameMap` are already sorted because it's a `TreeMap` ; but it seems that the ordering is lost when doing ` new HashSet<>(frameMap.values())`. 

By simply keeping the Collection `frameMap.values()` (of the TreeMap implementation) it seems to keep the order. I modified the return type of the existing method, which is used at other places but I don't know if they do need a HashSet or are fine with this Collection. Maybe it's better to create a new `getSortedFrames()` method ? 